### PR TITLE
GPII-4392: Pinned CouchDB docker container version to latest 2.x release.

### DIFF
--- a/src/js/dockerWorker.js
+++ b/src/js/dockerWorker.js
@@ -108,7 +108,7 @@ fluid.defaults("gpii.test.couchdb.worker.docker", {
     },
     commandTemplates: {
         listContainers:  "docker ps -a --filter label=%options.containerLabel --format '{{ json . }}'",
-        createContainer: "docker run -d -l %options.containerLabel -p %options.port:5984 --name %containerName couchdb",
+        createContainer: "docker run -d -l %options.containerLabel -p %options.port:5984 --name %containerName couchdb:2.3.1",
         startContainer:  "docker start %containerId",
         removeContainer: "docker rm -f %containerId",
         stopContainer:   "docker stop %containerId"


### PR DESCRIPTION
See [GPII-4392](https://issues.gpii.net/browse/GPII-4392) for details.