### PR TITLE
GH-6: Update for default branch rename to main (resolves #6)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 14.x]
 
     env:
       HEADLESS: true

--- a/docs/test-fixtures.md
+++ b/docs/test-fixtures.md
@@ -18,7 +18,7 @@ for use in Fluid IoC Tests.
 
 ## `fluid.test.couchdb.testEnvironment.lucene`
 
-A test environment that provides both CouchDB and [couchdb-lucene](https://github.com/rnewson/couchdb-lucene).  Uses 
+A test environment that provides both CouchDB and [couchdb-lucene](https://github.com/rnewson/couchdb-lucene).  Uses
 [the `fluid.test.couchdb.harness.lucene` grade provided by this package](./harness.md).
 
 ### Component Options
@@ -53,11 +53,11 @@ documentation](./harness.md).
 | --------------- | ---------- | ----------- |
 | `rawModules`    | `{Object}` | The tests to execute.  Note that your tests must be defined in `rawModules` rather than `modules`,  otherwise they will not be able to trigger the automatic startup and shutdown sequence needed to use the harness safely. |
 | `sequenceGrade` | `{String}` | The sequence grade to use with any test that does not already have a sequence grade. |
- 
+
 ## `fluid.test.couchdb.request`
 
 A grade derived from
-[`kettle.test.request.http`](https://github.com/fluid-project/kettle/blob/master/docs/KettleTestingFramework.md#the-kettle-testing-framework)
+[`kettle.test.request.http`](https://github.com/fluid-project/kettle/blob/main/docs/KettleTestingFramework.md#the-kettle-testing-framework)
 for use in retrieving and then inspecting results from the test harness.
 
 ### Component Options


### PR DESCRIPTION
Also updated CI to run on the latest LTS versions of Node

Resolves #6 